### PR TITLE
Call FAB's onClick() method rather than calling click listener direct…

### DIFF
--- a/library/src/main/java/com/github/clans/fab/Label.java
+++ b/library/src/main/java/com/github/clans/fab/Label.java
@@ -302,7 +302,7 @@ public class Label extends TextView {
 
         mGestureDetector.onTouchEvent(event);
 
-        mFab.getOnClickListener().onClick(this);
+        mFab.callOnClick();
 
         return super.onTouchEvent(event);
     }


### PR DESCRIPTION
…ly- causes the View argument to be the FAB, which maintains the right ID for the FAM to handle it correctly.