### PR TITLE
Changes to set the resourceID of the open and close FAM button's icon.

### DIFF
--- a/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
+++ b/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
@@ -82,7 +82,9 @@ public class FloatingActionMenu extends ViewGroup {
     private int mMenuColorPressed;
     private int mMenuColorRipple;
     private Drawable mOpenIcon; // Netscout change: can now be set at runtime, and open & close icons replace single (rotating) toggle icon
+    private int mOpenIconResId; // Netscout change: Automation needs a unique ID for the button
     private Drawable mCloseIcon; // Netscout change: use this instead of the rotated mIcon.
+    private int mCloseIconResId; // Netscout change: Automation needs a unique ID for the button
     private int mAnimationDelayPerItem = DEFAULT_ANIMATION_DELAY_PER_ITEM; // Netscout addition: default value
     private Interpolator mOpenInterpolator;
     private Interpolator mCloseInterpolator;
@@ -280,9 +282,11 @@ public class FloatingActionMenu extends ViewGroup {
 
         mImageOpenButton = new ImageView(getContext());
         mImageOpenButton.setImageDrawable(mOpenIcon);
+        mImageOpenButton.setId(mOpenIconResId);
 
         mImageCloseButton = new ImageView(getContext());
         mImageCloseButton.setImageDrawable(mCloseIcon);
+        mImageCloseButton.setId(mCloseIconResId);
 
         addView(mMenuButton, super.generateDefaultLayoutParams());
 
@@ -1152,15 +1156,19 @@ public class FloatingActionMenu extends ViewGroup {
     }
 
     // Netscout addition
-    public void setOpenIcon(Drawable icon) {
+    public void setOpenIcon(Drawable icon, int resId) {
         mOpenIcon = icon;
+        mOpenIconResId = resId;
         mImageOpenButton.setImageDrawable(mOpenIcon);
+        mImageOpenButton.setId(mOpenIconResId);
     }
 
     // Netscout addition
-    public void setCloseIcon(Drawable icon) {
+    public void setCloseIcon(Drawable icon, int resId) {
         mCloseIcon = icon;
+        mCloseIconResId = resId;
         mImageCloseButton.setImageDrawable(mCloseIcon);
+        mImageCloseButton.setId(mCloseIconResId);
     }
 
     public ImageView getOpenButton() {

--- a/sample/src/main/java/com/github/clans/fab/sample/MenusFragment.java
+++ b/sample/src/main/java/com/github/clans/fab/sample/MenusFragment.java
@@ -143,7 +143,7 @@ public class MenusFragment extends Fragment {
             menuFabPrimaryMenu.addMenuButton(fab);
         }
 
-        menuFabPrimaryMenu.setOpenIcon(getContext().getDrawable(R.drawable.ic_star));
+        menuFabPrimaryMenu.setOpenIcon(getContext().getDrawable(R.drawable.ic_star), 0);
 
         menuFabPrimaryMenu.setVisibility(View.VISIBLE);
 


### PR DESCRIPTION
This is needed by Andromeda automation to test FAM operation.  Andromeda UI side changes will also be need to utilize this once this PR is merged in.

See Harold's notes below:

From: Wilson, Harold 
Sent: Wednesday, September 27, 2017 3:45 PM
To: Eide, Erik <Erik.Eide@netscout.com>

I am writing Float Action Menu tests in Automation. 
Developers are not giving automation a lot to work with here.

![automationissue](https://user-images.githubusercontent.com/5199533/30996015-7e9744f0-a472-11e7-9dce-d656553bfc9a.jpg)

This is the Icon inside the red button. I cannot use the Red Button itself as it is “NAF” Not Accessibility Friendly a.k.a. Not Accessible to Framework.
If Developers could add a unique “Resource Id” or even  a description “content-desc”” here, that would be helpful.
Otherwise I am left with UI Coordinates (see bounds) and I hate using that.

